### PR TITLE
Declare callable return type

### DIFF
--- a/src/Factories/FuncService.php
+++ b/src/Factories/FuncService.php
@@ -56,6 +56,7 @@ class FuncService extends Service
 
     /**
      * @inheritDoc
+     * @return callable
      */
     public function __invoke(ContainerInterface $c)
     {


### PR DESCRIPTION
The subclass may declare a more specific return type. Explicitly annotating it makes psalm aware that FuncService can only ever return callables and thus prevents a MixedFunctionCall error