### PR TITLE
Allow service instances as dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [[*next-version*]] - YYYY-MM-DD
+### Changed
+- The `Constructor`, `FuncService`, `ServiceList`, `StringService`, `Extension`, and `ArrayExtension` services now
+  accept other service instances as dependencies, in addition to strings (#14).
+- The `ResolveKeysCabableTrait::resolveKeys()` method is now deprecated. Clients should use the `resolveDeps()` method
+  instead (#14).
 
 ## [0.1.1-alpha2] - 2022-01-05
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,12 @@
     },
     "scripts": {
         "test": "phpunit",
-        "csfix": "php-cs-fixer fix -vvv"
+        "csfix": "php-cs-fixer fix -vvv",
+        "psalm": "psalm --show-info --threads=8 --diff"
+    },
+    "config": {
+        "allow-plugins": {
+          "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     }
 }

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -48,7 +48,7 @@ class Extension extends Service
      */
     public function __invoke(ContainerInterface $c, $prev = null)
     {
-        $deps = $this->resolveKeys($c, $this->dependencies);
+        $deps = $this->resolveDeps($c, $this->dependencies);
         array_unshift($deps, $prev);
 
         return ($this->definition)(...$deps);

--- a/src/Extensions/ArrayExtension.php
+++ b/src/Extensions/ArrayExtension.php
@@ -48,6 +48,6 @@ class ArrayExtension extends Service
      */
     public function __invoke(ContainerInterface $c, $prev = [])
     {
-        return array_merge($prev, $this->resolveKeys($c, $this->dependencies));
+        return array_merge($prev, $this->resolveDeps($c, $this->dependencies));
     }
 }

--- a/src/Factories/Constructor.php
+++ b/src/Factories/Constructor.php
@@ -47,7 +47,7 @@ class Constructor extends Service
      */
     public function __invoke(ContainerInterface $c)
     {
-        $deps = $this->resolveKeys($c, $this->dependencies);
+        $deps = $this->resolveDeps($c, $this->dependencies);
         $className = $this->className;
 
         return new $className(...$deps);

--- a/src/Factories/FuncService.php
+++ b/src/Factories/FuncService.php
@@ -59,7 +59,7 @@ class FuncService extends Service
      */
     public function __invoke(ContainerInterface $c)
     {
-        $deps = $this->resolveKeys($c, $this->dependencies);
+        $deps = $this->resolveDeps($c, $this->dependencies);
 
         /**
          * @psalm-suppress MissingClosureReturnType Cannot declare mixed until PHP 8

--- a/src/Factories/ServiceList.php
+++ b/src/Factories/ServiceList.php
@@ -57,6 +57,6 @@ class ServiceList extends Service
      */
     public function __invoke(ContainerInterface $c)
     {
-        return $this->resolveKeys($c, $this->dependencies);
+        return $this->resolveDeps($c, $this->dependencies);
     }
 }

--- a/src/Factories/StringService.php
+++ b/src/Factories/StringService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Dhii\Services\Factories;
 
+use Dhii\Services\ResolveKeysCapableTrait;
 use Dhii\Services\Service;
 use Psr\Container\ContainerInterface;
 
@@ -24,6 +25,8 @@ use Psr\Container\ContainerInterface;
  */
 class StringService extends Service
 {
+    use ResolveKeysCapableTrait;
+
     /** @var string */
     protected $format;
 
@@ -54,7 +57,7 @@ class StringService extends Service
         $replace = [];
         foreach ($this->dependencies as $idx => $dependency) {
             $idx = (string) $idx;
-            $replace['{' . $idx . '}'] = strval($c->get($dependency));
+            $replace['{' . $idx . '}'] = (string) $this->resolveSingleDep($c, $dependency);
         }
 
         return strtr($this->format, $replace);

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -47,7 +47,7 @@ class Factory extends Service
      */
     public function __invoke(ContainerInterface $c)
     {
-        $deps = $this->resolveKeys($c, $this->dependencies);
+        $deps = $this->resolveDeps($c, $this->dependencies);
 
         return ($this->definition)(...$deps);
     }

--- a/src/ResolveKeysCapableTrait.php
+++ b/src/ResolveKeysCapableTrait.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Dhii\Services;
 
-use Generator;
 use Psr\Container\ContainerInterface;
 
 trait ResolveKeysCapableTrait
@@ -12,31 +11,23 @@ trait ResolveKeysCapableTrait
     /**
      * Resolves a set of service keys using a given container.
      *
-     * @param ContainerInterface $c    The container to use for service resolution.
-     * @param array<string>      $keys The services keys to resolve.
-     *
-     * @return array<int,mixed> A list containing the resolved service values, in the same order as in $keys.
-     */
-    protected function resolveKeys(ContainerInterface $c, array $keys): array
-    {
-        return array_values($this->resolveDeps($c, $keys));
-    }
-
-    /**
-     * Resolves a set of service keys using a given container.
-     *
-     * @param ContainerInterface $c    The container to use for service resolution.
-     * @param array<string>      $keys The services keys to resolve.
+     * @param ContainerInterface    $c    The container to use for service resolution.
+     * @param array<Service|string> $deps The list of services dependencies, or their keys.
      *
      * @return array<string,mixed> A map of specified service keys to their resolved values,
      *                             in the same order as in $keys.
      */
-    protected function resolveDeps(ContainerInterface $c, array $keys): array
+    protected function resolveDeps(ContainerInterface $c, array $deps): array
     {
-        return iterator_to_array((function () use ($c, $keys): Generator {
-            foreach ($keys as $key) {
-                yield $key => $c->get($key);
+        $result = [];
+        foreach ($deps as $dep) {
+            if ($dep instanceof Service) {
+                $result[] = $dep($c);
+            } else {
+                $result[] = $c->get($dep);
             }
-        })());
+        }
+
+        return $result;
     }
 }

--- a/src/ResolveKeysCapableTrait.php
+++ b/src/ResolveKeysCapableTrait.php
@@ -34,7 +34,7 @@ trait ResolveKeysCapableTrait
      *
      * @param ContainerInterface     $c    The container to use for service resolution.
      * @param array<string|callable> $deps The list of dependencies, where each is either a callable definitions or key.
-     * @psalm-param ServiceRef       $deps
+     * @psalm-param ServiceRef[]     $deps
      *
      * @return array<string,mixed> A map of specified service keys to their resolved values,
      *                             in the same order as in $keys.

--- a/src/ResolveKeysCapableTrait.php
+++ b/src/ResolveKeysCapableTrait.php
@@ -24,7 +24,7 @@ trait ResolveKeysCapableTrait
     }
 
     /**
-     * Resolves a set of service keys using a given container.
+     * Resolves a set of dependencies using a given container.
      *
      * @param ContainerInterface    $c    The container to use for service resolution.
      * @param array<Service|string> $deps The list of services dependencies, or their keys.

--- a/src/ResolveKeysCapableTrait.php
+++ b/src/ResolveKeysCapableTrait.php
@@ -6,6 +6,11 @@ namespace Dhii\Services;
 
 use Psr\Container\ContainerInterface;
 
+/**
+ * Functionality for resolving a service key.
+ *
+ * @psalm-type ServiceRef = string|callable(ContainerInterface): mixed
+ */
 trait ResolveKeysCapableTrait
 {
     /**
@@ -13,8 +18,9 @@ trait ResolveKeysCapableTrait
      *
      * @deprecated Use {@see resolveDeps()} instead.
      *
-     * @param ContainerInterface $c    The container to use for service resolution.
-     * @param array<string>      $keys The services keys to resolve.
+     * @param ContainerInterface      $c    The container to use for service resolution.
+     * @param array<string|callable>  $keys The services keys to resolve.
+     * @psalm-param array<ServiceRef> $keys
      *
      * @return array<int,mixed> A list containing the resolved service values, in the same order as in $keys.
      */
@@ -28,6 +34,7 @@ trait ResolveKeysCapableTrait
      *
      * @param ContainerInterface     $c    The container to use for service resolution.
      * @param array<string|callable> $deps The list of dependencies, where each is either a callable definitions or key.
+     * @psalm-param ServiceRef       $deps
      *
      * @return array<string,mixed> A map of specified service keys to their resolved values,
      *                             in the same order as in $keys.
@@ -47,6 +54,7 @@ trait ResolveKeysCapableTrait
      *
      * @param ContainerInterface  $c   The container to use for service resolution.
      * @param string|callable     $dep The service definition, or its key.
+     * @psalm-param ServiceRef    $dep
      *
      * @return mixed The resolved service value.
      */

--- a/src/ResolveKeysCapableTrait.php
+++ b/src/ResolveKeysCapableTrait.php
@@ -36,8 +36,7 @@ trait ResolveKeysCapableTrait
      * @param array<string|callable> $deps The list of dependencies, where each is either a callable definitions or key.
      * @psalm-param ServiceRef[]     $deps
      *
-     * @return array<string,mixed> A map of specified service keys to their resolved values,
-     *                             in the same order as in $keys.
+     * @return array<int,mixed> A list containing the resolved dependencies, in the same order as given in $keys.
      */
     protected function resolveDeps(ContainerInterface $c, array $deps): array
     {

--- a/src/ResolveKeysCapableTrait.php
+++ b/src/ResolveKeysCapableTrait.php
@@ -26,8 +26,8 @@ trait ResolveKeysCapableTrait
     /**
      * Resolves a set of dependencies using a given container.
      *
-     * @param ContainerInterface    $c    The container to use for service resolution.
-     * @param array<Service|string> $deps The list of services dependencies, or their keys.
+     * @param ContainerInterface     $c    The container to use for service resolution.
+     * @param array<string|callable> $deps The list of dependencies, where each is either a callable definitions or key.
      *
      * @return array<string,mixed> A map of specified service keys to their resolved values,
      *                             in the same order as in $keys.
@@ -45,14 +45,14 @@ trait ResolveKeysCapableTrait
     /**
      * Resolves a single dependency using a given container.
      *
-     * @param ContainerInterface $c   The container to use for service resolution.
-     * @param Service|string     $dep The service definition, or its key.
+     * @param ContainerInterface  $c   The container to use for service resolution.
+     * @param string|callable     $dep The service definition, or its key.
      *
      * @return mixed The resolved service value.
      */
     protected function resolveSingleDep(ContainerInterface $c, $dep)
     {
-        return $dep instanceof Service
+        return is_callable($dep)
             ? $dep($c)
             : $c->get($dep);
     }

--- a/src/ResolveKeysCapableTrait.php
+++ b/src/ResolveKeysCapableTrait.php
@@ -9,7 +9,7 @@ use Psr\Container\ContainerInterface;
 /**
  * Functionality for resolving a service key.
  *
- * @psalm-type ServiceRef = string|callable(ContainerInterface): mixed
+ * @psalm-import-type ServiceRef from Service
  */
 trait ResolveKeysCapableTrait
 {

--- a/src/ResolveKeysCapableTrait.php
+++ b/src/ResolveKeysCapableTrait.php
@@ -36,13 +36,24 @@ trait ResolveKeysCapableTrait
     {
         $result = [];
         foreach ($deps as $dep) {
-            if ($dep instanceof Service) {
-                $result[] = $dep($c);
-            } else {
-                $result[] = $c->get($dep);
-            }
+            $result[] = $this->resolveSingleDep($c, $dep);
         }
 
         return $result;
+    }
+
+    /**
+     * Resolves a single dependency using a given container.
+     *
+     * @param ContainerInterface $c   The container to use for service resolution.
+     * @param Service|string     $dep The service definition, or its key.
+     *
+     * @return mixed The resolved service value.
+     */
+    protected function resolveSingleDep(ContainerInterface $c, $dep)
+    {
+        return $dep instanceof Service
+            ? $dep($c)
+            : $c->get($dep);
     }
 }

--- a/src/ResolveKeysCapableTrait.php
+++ b/src/ResolveKeysCapableTrait.php
@@ -11,6 +11,21 @@ trait ResolveKeysCapableTrait
     /**
      * Resolves a set of service keys using a given container.
      *
+     * @deprecated Use {@see resolveDeps()} instead.
+     *
+     * @param ContainerInterface $c    The container to use for service resolution.
+     * @param array<string>      $keys The services keys to resolve.
+     *
+     * @return array<int,mixed> A list containing the resolved service values, in the same order as in $keys.
+     */
+    protected function resolveKeys(ContainerInterface $c, array $keys): array
+    {
+        return $this->resolveDeps($c, $keys);
+    }
+
+    /**
+     * Resolves a set of service keys using a given container.
+     *
      * @param ContainerInterface    $c    The container to use for service resolution.
      * @param array<Service|string> $deps The list of services dependencies, or their keys.
      *

--- a/src/Service.php
+++ b/src/Service.php
@@ -22,7 +22,7 @@ use UnexpectedValueException;
  * @see   __invoke()
  * @see   ContainerInterface
  *
- * @psalm-import-type ServiceRef from ResolveKeysCapableTrait
+ * @psalm-type ServiceRef = string|callable(ContainerInterface): mixed
  */
 abstract class Service
 {

--- a/src/Service.php
+++ b/src/Service.php
@@ -25,14 +25,14 @@ use UnexpectedValueException;
 abstract class Service
 {
     /**
-     * @var array<string|Service>
+     * @var array<string|callable>
      */
     protected $dependencies;
 
     /**
      * Constructor.
      *
-     * @param array<string|Service> $dependencies A list of dependencies, as either a {@link Service} instance or a key.
+     * @param array<string|callable> $dependencies A list of dependencies, where each is a callable definition or a key.
      */
     public function __construct(array $dependencies)
     {
@@ -42,7 +42,7 @@ abstract class Service
     /**
      * Retrieves the keys of dependent services.
      *
-     * @return array<string|Service> A list containing a mix of {@link Service} instances and string key.
+     * @return array<string|callable> A list containing a mix of callable definitions and string keys.
      */
     public function getDependencies(): array
     {
@@ -52,7 +52,7 @@ abstract class Service
     /**
      * Creates a copy of this service with different dependency keys.
      *
-     * @param array<string|Service> $dependencies A list of dependencies, as either a {@link Service} instance or a key.
+     * @param array<string|callable> $dependencies A list of dependencies, where each is a callable definition or a key.
      *
      * @return static The newly created service instance.
      */

--- a/src/Service.php
+++ b/src/Service.php
@@ -22,7 +22,8 @@ use UnexpectedValueException;
  * @see   __invoke()
  * @see   ContainerInterface
  *
- * @psalm-type ServiceRef = string|callable(ContainerInterface): mixed
+ * @psalm-type ServiceFactory = callable(ContainerInterface): mixed
+ * @psalm-type ServiceRef = string|ServiceFactory
  */
 abstract class Service
 {

--- a/src/Service.php
+++ b/src/Service.php
@@ -15,8 +15,9 @@ use UnexpectedValueException;
  * the magic {@link __invoke()} method. The signature of this method is equivalent to that of regular service definition
  * functions, in that they accept a {@link ContainerInterface} instance.
  *
- * Services are also aware of any services that they depend on, by key. These keys may be used by derivations of this
- * class to achieve some automation, be it during run-time or for static analysis purposes.
+ * Services also contain a record of any other services that they depend on, either by their key or as instance. These
+ * dependencies may be used by derivations of this class to achieve some automation, be it during run-time or for
+ * static analysis purposes.
  *
  * @see   __invoke()
  * @see   ContainerInterface
@@ -24,14 +25,14 @@ use UnexpectedValueException;
 abstract class Service
 {
     /**
-     * @var string[]
+     * @var array<string|Service>
      */
     protected $dependencies;
 
     /**
      * Constructor.
      *
-     * @param string[] $dependencies A list of keys that correspond to other services that this service depends on.
+     * @param array<string|Service> $dependencies A list of dependencies, as either a {@link Service} instance or a key.
      */
     public function __construct(array $dependencies)
     {
@@ -41,7 +42,7 @@ abstract class Service
     /**
      * Retrieves the keys of dependent services.
      *
-     * @return string[] A list of strings each representing the key of a service.
+     * @return array<string|Service> A list containing a mix of {@link Service} instances and string key.
      */
     public function getDependencies(): array
     {
@@ -51,7 +52,7 @@ abstract class Service
     /**
      * Creates a copy of this service with different dependency keys.
      *
-     * @param array $dependencies The new service dependency keys.
+     * @param array<string|Service> $dependencies A list of dependencies, as either a {@link Service} instance or a key.
      *
      * @return static The newly created service instance.
      */

--- a/src/Service.php
+++ b/src/Service.php
@@ -21,11 +21,14 @@ use UnexpectedValueException;
  *
  * @see   __invoke()
  * @see   ContainerInterface
+ *
+ * @psalm-import-type ServiceRef from ResolveKeysCapableTrait
  */
 abstract class Service
 {
     /**
      * @var array<string|callable>
+     * @psalm-var ServiceRef[]
      */
     protected $dependencies;
 
@@ -33,6 +36,7 @@ abstract class Service
      * Constructor.
      *
      * @param array<string|callable> $dependencies A list of dependencies, where each is a callable definition or a key.
+     * @psalm-param ServiceRef[]     $dependencies
      */
     public function __construct(array $dependencies)
     {
@@ -43,6 +47,7 @@ abstract class Service
      * Retrieves the keys of dependent services.
      *
      * @return array<string|callable> A list containing a mix of callable definitions and string keys.
+     * @psalm-return ServiceRef[]
      */
     public function getDependencies(): array
     {
@@ -53,6 +58,7 @@ abstract class Service
      * Creates a copy of this service with different dependency keys.
      *
      * @param array<string|callable> $dependencies A list of dependencies, where each is a callable definition or a key.
+     * @psalm-param ServiceRef[]     $dependencies
      *
      * @return static The newly created service instance.
      */

--- a/tests/unit/ResolveKeysCapableTraitTest.php
+++ b/tests/unit/ResolveKeysCapableTraitTest.php
@@ -37,16 +37,24 @@ class ResolveKeysCapableTraitTest extends TestCase
         $container = $this->getMockForAbstractClass(ContainerInterface::class);
 
         // The service dependency
-        $depValue = new \stdClass();
+        $depValue1 = new \stdClass();
         $depService = $this->getMockForAbstractClass(Service::class, [[$keys[1]]]);
         $depService->expects(static::once())
             ->method('__invoke')
             ->with($container)
-            ->willReturnCallback(function (ContainerInterface $c) use ($depValue, $keys) {
+            ->willReturnCallback(function (ContainerInterface $c) use ($depValue1) {
                // Simulate dependency
-               $c->get($keys[1]);
-               return $depValue;
+               $c->get('bar');
+               return $depValue1;
             });
+
+        // The callable dependency
+        $depValue2 = new \stdClass();
+        $depCallable = function (ContainerInterface $c) use ($depValue2) {
+            // Simulate dependency
+            $c->get('baz');
+            return $depValue2;
+        };
 
         // The container mock
         $container = $this->getMockForAbstractClass(ContainerInterface::class);
@@ -60,9 +68,9 @@ class ResolveKeysCapableTraitTest extends TestCase
         $method = AccessibleMethod::create($subject, 'resolveDeps');
 
         // The test
-        $args = ['foo', $depService, 'baz'];
-        $result = $method($container, $args);
-        $expected = [$values[0], $depValue, $values[2]];
+        $deps = ['foo', $depService, $depCallable];
+        $result = $method($container, $deps);
+        $expected = [$values[0], $depValue1, $depValue2];
 
         static::assertEquals($expected, $result);
     }


### PR DESCRIPTION
Implements the changes proposed in #14.

API Changes:
* The public API is unchanged. Consumers that only make use of the service implementations are unaffected, and may now pass `Service` instance in dependency arrays.
* The internal API has changed slightly. Consumers that extend or implement service implementations should now always use the `ResolveKeysCapableTrait::resolveDeps()` method. The `resolveKeys()` method in the same trait has been deprecated.