### PR TITLE
Class name improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [[*next-version*]] - YYYY-MM-DD
+### Added
+- New `Instance` alias for the `Constructor` helper.
+- New `Callback` alias for the `FuncService` helper.
+- New `TemplatedStr` alias for the `StringService` helper.
 
 ## [0.1.1-alpha3] - 2023-02-01
 ### Added

--- a/src/Factories/Callback.php
+++ b/src/Factories/Callback.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dhii\Services\Factories;
+
+class Callback extends FuncService
+{
+}

--- a/src/Factories/Instance.php
+++ b/src/Factories/Instance.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dhii\Services\Factories;
+
+class Instance extends Constructor
+{
+}

--- a/src/Factories/TemplatedStr.php
+++ b/src/Factories/TemplatedStr.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dhii\Services\Factories;
+
+class TemplatedStr extends StringService
+{
+}

--- a/tests/unit/Factories/ConstructorTest.php
+++ b/tests/unit/Factories/ConstructorTest.php
@@ -3,6 +3,7 @@
 namespace Dhii\Services\Tests\Unit\Factories;
 
 use Dhii\Services\Factories\Constructor;
+use Dhii\Services\Factories\Instance;
 use Dhii\Services\Service;
 use Dhii\Services\Tests\Helpers\MockContainer;
 use Exception;
@@ -21,6 +22,14 @@ class ConstructorTest extends TestCase
     public function testIsService()
     {
         static::assertInstanceOf(Service::class, new Constructor(''));
+    }
+
+    /**
+     * @since [*next-version*]
+     */
+    public function testAlias()
+    {
+        static::assertInstanceOf(Constructor::class, new Instance(''));
     }
 
     /**

--- a/tests/unit/Factories/FuncServiceTest.php
+++ b/tests/unit/Factories/FuncServiceTest.php
@@ -2,6 +2,7 @@
 
 namespace Dhii\Services\Tests\Unit\Factories;
 
+use Dhii\Services\Factories\Callback;
 use Dhii\Services\Factories\FuncService;
 use Dhii\Services\Service;
 use Dhii\Services\Tests\Helpers\MockContainer;
@@ -22,6 +23,17 @@ class FuncServiceTest extends TestCase
         });
 
         static::assertInstanceOf(Service::class, $subject);
+    }
+
+    /**
+     * @since [*next-version*]
+     */
+    public function testAlias()
+    {
+        $subject = new Callback([], function () {
+        });
+
+        static::assertInstanceOf(FuncService::class, $subject);
     }
 
     /**

--- a/tests/unit/Factories/StringServiceTest.php
+++ b/tests/unit/Factories/StringServiceTest.php
@@ -3,6 +3,7 @@
 namespace Dhii\Services\Tests\Unit\Factories;
 
 use Dhii\Services\Factories\StringService;
+use Dhii\Services\Factories\TemplatedStr;
 use Dhii\Services\Service;
 use Dhii\Services\Tests\Helpers\MockContainer;
 use PHPUnit\Framework\TestCase;
@@ -19,6 +20,14 @@ class StringServiceTest extends TestCase
     public function testIsService()
     {
         static::assertInstanceOf(Service::class, new StringService(''));
+    }
+
+    /**
+     * @since [*next-version*]
+     */
+    public function testAlias()
+    {
+        static::assertInstanceOf(StringService::class, new TemplatedStr(''));
     }
 
     /**


### PR DESCRIPTION
Adds more human-friendly aliases for the following service helper classes:

* `Instance` -> `Constructor`
* `Callback` -> `FuncService`
* `TemplatedStr` -> `StringService`